### PR TITLE
Defer kms initialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,16 +14,16 @@ class ServerlessPlugin {
         }
         this.configureProxy();
 
-        this.kms = new AWS.KMS({
-            region: this.serverless.service.provider.region
-        });
-
         this.hooks = {
             'before:deploy:createDeploymentArtifacts': this.encryptVars.bind(this)
         };
     }
 
     encryptVars() {
+        this.kms = new AWS.KMS({
+            region: this.serverless.service.provider.region
+        });
+
         this.serverless.cli.log('Encrypting Lambda environment variables...');
         return this.ensureKmsKeyExists()
             .then(() => this.encryptVarsIn(this.serverless.service.provider, 'all function'))


### PR DESCRIPTION
According to the serverless documentation at https://serverless.com/framework/docs/providers/aws/guide/plugins/
Variable references in the serverless instance are not resolved before a Plugin's constructor is called

This means that the service was only working for region us-east-1

To test just create a serverless.yml with the following
```
provider:
  name: aws
  region: ${opt:region}
````
and run the deploy with

`$ sls deploy --region eu-west-1`