### PR TITLE
change hook event

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class ServerlessPlugin {
         this.configureProxy();
 
         this.hooks = {
-            'before:deploy:createDeploymentArtifacts': this.encryptVars.bind(this)
+            'package:createDeploymentArtifacts': this.encryptVars.bind(this)
         };
     }
 


### PR DESCRIPTION
use 'package:createDeploymentArtifacts' hook insted of 'before:deploy:createDeploymentArtifacts'(deprecated).

https://serverless.com/blog/serverless-v1.12.0/
https://github.com/serverless/serverless/blob/07f837ddb67a40cee3e0c6b238e165023b4b7725/lib/plugins/deploy/deploy.js#L14-L19